### PR TITLE
feat: add among_HML#fork#init_jump() and deprecate fork#init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,28 +55,17 @@ in your vimrc or init.vim.
 ```vim
 set scrolloff=0 " recommended (default)
 
-" if you prefer to jump in 1/4 or 3/4 height of lines (i.e., 25% or 75% height);
-nnoremap <silent> K :<c-u>call among_HML#jump(25)<cr>
-nnoremap <silent> J :<c-u>call among_HML#jump(75)<cr>
-
-onoremap <silent> K :call among_HML#jump(25)<cr>
-onoremap <silent> J :call among_HML#jump(75)<cr>
-
-" optional:
-" Mnemonic: Get the Keyword
-nnoremap gK K
-" Mnemonic: <space>-leaving Join
-nnoremap <space>J J
-```
-
-When either `has('nvim-0.3.0')` or `has('patch-8.2.1978')` returns `1`,
-you can define keymappings at once with `<Cmd>` as below:
-
-```vim
+" Jump in 1/4 or 3/4 height of lines (i.e., 25% or 75% height);
 noremap <silent> K <Cmd>call among_HML#jump(25)<cr>
 noremap <silent> J <Cmd>call among_HML#jump(75)<cr>
+
+" Optional mappings with mnemonics:
+" Get the Keyword
 nnoremap gK K
+xnoremap gK K
+" <Space>-leaving Join in contrast to the default `gJ`
 nnoremap <space>J J
+xnoremap <space>J J
 ```
 
 ### Fork Motion

--- a/README.md
+++ b/README.md
@@ -88,4 +88,7 @@ ounmap M
 ```
 
 Now, you can spare your keymappings.
-For more information, please read documentation.
+
+For more examples and informations, please read documentation
+([online](https://github.com/kaile256/vim-among_HML/blob/master/doc/among_HML.txt),
+or `:h among_HML` in your Vim/Neovim)

--- a/README.md
+++ b/README.md
@@ -87,38 +87,15 @@ you can jump in fork.
 ```vim
 let g:submode_keep_leaving_key = 1 " recommended
 
-" Note: in vimrc, this lines must be loaded after kana/vim-submode is loaded
-call among_HML#fork#init('M', '50', {
+noremap <silent> M <Cmd>call among_HML#fork#init_jump(
+      \ 'M', '50', {
       \ 'H': '0',
       \ 'K': '25',
       \ 'J': '75',
       \ 'L': '100',
-      \ })
-```
-
-For lazy load, you can also define keymaps like below
-
-```vim
-nnoremap <silent> M :call among_HML#fork#init('M', '50', {
-      \ 'H': '0',
-      \ 'K': '25',
-      \ 'J': '75',
-      \ 'L': '100',
-      \ })<bar>
-      \ call feedkeys('M')<cr>
-```
-
-When either `has('nvim-0.3.0')` or `has('patch-8.2.1978')` returns `1`,
-you can define keymappings at once with `<Cmd>` as below:
-
-```vim
-noremap <silent> M <Cmd>call among_HML#fork#init('M', '50', {
-      \ 'H': '0',
-      \ 'K': '25',
-      \ 'J': '75',
-      \ 'L': '100',
-      \ })<bar>
-      \ call feedkeys('M')<cr>
+      \ })<CR>
+" Fork mappings are usually annoying in Operator-pending mode.
+ounmap M
 ```
 
 Now, you can spare your keymappings.

--- a/README.md
+++ b/README.md
@@ -21,25 +21,19 @@ Install the plugin using your favorite package manager
 
 ### For dein.vim
 
-```vim
-call dein#add('kaile256/vim-among_HML')
-```
-
-or if you prefer to write in toml and to load this plugin lazy, add
-
-```vim
-call dein#load_toml('foo.toml', {'lazy': 1})
-```
-
-in your vimrc and then, add
+Install the plugin using your favorite package manager.
+This is a sample configuration in TOML format
+for [Dein](https://github.com/Shougo/dein.vim) users:
 
 ```toml
 [[plugin]]
 repo = 'kaile256/vim-among_HML'
-on_func = 'among_HML#'
+lazy = 1
+on_func = ['among_HML#']
+hook_add = '''
+" Write your configuration referring to the examples below.
+'''
 ```
-
-in foo.toml.
 
 ## Examples
 

--- a/autoload/among_HML/fork.vim
+++ b/autoload/among_HML/fork.vim
@@ -29,7 +29,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 "}}}
 
-function! among_HML#fork#init(start_key, percentage, combinations)
+function! s:define_submode(start_key, percentage, combinations)
   if has('nvim-0.3.0') || has('patch-8.2.1978')
     let call = '<Cmd>call '
     let modes = 'nx'
@@ -54,6 +54,15 @@ function! among_HML#fork#init(start_key, percentage, combinations)
       echoerr v:exception .': this function depends on kana/vim-submode, please install it and check your runtime path'
     endif
   endtry
+endfunction
+
+function! among_HML#fork#init_jump(start_key, perc, combi) abort
+  call s:define_submode(a:start_key, a:perc, a:combi)
+  call feedkeys(a:start_key, 'm')
+endfunction
+
+function! among_HML#fork#init(start_key, perc, combi) abort
+  call s:define_submode(a:start_key, a:perc, a:combi)
 endfunction
 
 " restore 'cpoptions' {{{1

--- a/autoload/among_HML/fork.vim
+++ b/autoload/among_HML/fork.vim
@@ -67,6 +67,8 @@ endfunction
 
 function! among_HML#fork#init(start_key, perc, combi) abort
   call s:define_submode(a:start_key, a:perc, a:combi)
+  echoerr '[among_HML/fork] among_HML#fork#init() is deprecated;'
+        \ 'use among_HML#fork#init_jump() instead'
 endfunction
 
 " restore 'cpoptions' {{{1

--- a/autoload/among_HML/fork.vim
+++ b/autoload/among_HML/fork.vim
@@ -32,22 +32,26 @@ set cpo&vim
 function! s:define_submode(start_key, percentage, combinations)
   if has('nvim-0.3.0') || has('patch-8.2.1978')
     let call = '<Cmd>call '
-    let modes = 'nx'
+    let modes = 'nxo'
   else
     let call = ':<c-u>call '
-    let modes = 'n'
+    let modes = 'no'
   endif
 
   let rhs = call .'among_HML#jump('. a:percentage .')<cr>'
 
   try
-    call submode#enter_with('HML/fork_'. a:start_key, modes, 's', a:start_key, rhs)
-    " Note: in operator, should jump directly to destination
-    call submode#enter_with('HML/fork_'. a:start_key, 'o', 's', a:start_key)
-
-    for lhs in keys(a:combinations)
-      " Note: option-x makes user leave from the submode
-      call submode#map('HML/fork_'. a:start_key, modes .'o', 'sx', lhs, call .'among_HML#jump('. a:combinations[lhs] .')<cr>')
+    let mode_name = 'HML/fork_'. a:start_key
+    for l:mode in split(modes, '\zs')
+      let maparg = maparg(a:start_key, l:mode)
+      if maparg ==# '' || maparg =~# 'among_HML#fork#init_jump'
+        call submode#enter_with(mode_name, l:mode, 's', a:start_key, rhs)
+        for lhs in keys(a:combinations)
+          " Note: option-x makes user leave from the submode
+          let sub_rhs = call .'among_HML#jump('. a:combinations[lhs] .')<CR>'
+          call submode#map(mode_name, l:mode, 'sx', lhs, sub_rhs)
+        endfor
+      endif
     endfor
   catch
     if !exists('*submode#enter_with')

--- a/doc/among_HML.txt
+++ b/doc/among_HML.txt
@@ -84,51 +84,48 @@ among_HML#fork#init({lhs}, {expr}, {dict})  *among_HML-among_HML#fork#init()*
 				\ 'J': '75',
 				\ })
 <
-		For lazy load, you can also defines keymaps like below:
+		For lazy load, you also have |among_HML#fork#init_jump()|.
+
+				       *among_HML-among_HML#fork#init_jump()*
+among_HML#fork#init_jump({lhs}, {expr}, {dict})
+		A wrapper function of |among_HML#fork#init()|. Define a submode
+		and then invoke it. This function is supposed to be used in
+		mappings.
 >
-		noremap <silent> M <Cmd>call among_HML#fork#init('M', '50', {
+		noremap <silent> M <Cmd>call among_HML#fork#init_jump(
+				\ 'M', '50', {
 				\ 'K': '25',
 				\ 'J': '75',
-				\ })<bar>
-				\ call feedkeys('M')<cr>
+				\ })<CR>
 <
 		If you prefer not to jump at first, leave the second argument
 		empty.
 >
-		noremap <silent> M <Cmd>call among_HML#fork#init('M', '', {
+		noremap <silent> M <Cmd>call among_HML#fork#init_jump(
+				\ 'M', '', {
 				\ 'K': '25',
 				\ 'J': '75',
-				\ })<bar>
-				\ call feedkeys('M')<cr>
-<
-		If you use `neovim >= 0.3.0`,
->
-		noremap <silent> M <Cmd>call among_HML#fork#init('M', '50', {
-				\ 'K': '25',
-				\ 'J': '75',
-				\ })<bar>
-				\ call feedkeys('M')<cr>
-<
-		This is a table to compare some ratio with percentage for
-		convenience
+				\ })<CR>
 
-		| ratio | percentage |
-		| ===== | ========== |
-		| 0     | 0          |
-		| 1/8   | 12.5       |
-		| 1/6   | 16.666667  |
-		| 1/4   | 25         |
-		| 1/3   | 33.333333  |
-		| 3/8   | 37.5       |
-		| ----- | ---------- |
-		| 1/2   | 50         |
-		| ----- | ---------- |
-		| 5/8   | 62.5       |
-		| 2/3   | 66.666667  |
-		| 3/4   | 75         |
-		| 5/6   | 83.333333  |
-		| 7/8   | 87.5       |
-		| 1     | 100        |
+For convenience, here are some ratio with percentage in the table below:
+
+	| ratio | percentage |
+	| ===== | ========== |
+	| 0     | 0          |
+	| 1/8   | 12.5       |
+	| 1/6   | 16.666667  |
+	| 1/4   | 25         |
+	| 1/3   | 33.333333  |
+	| 3/8   | 37.5       |
+	| ----- | ---------- |
+	| 1/2   | 50         |
+	| ----- | ---------- |
+	| 5/8   | 62.5       |
+	| 2/3   | 66.666667  |
+	| 3/4   | 75         |
+	| 5/6   | 83.333333  |
+	| 7/8   | 87.5       |
+	| 1     | 100        |
 
 ==============================================================================
 EXAMPLES						 *among_HML-examples*

--- a/doc/among_HML.txt
+++ b/doc/among_HML.txt
@@ -136,69 +136,81 @@ You must install kana/vim-submode(https://github.com/kana/vim-submode) to use
 
 9 patterns of lines:
 >
-	noremap <silent> H <Cmd>call among_HML#fork#init_jump('H', '0', {
-	\ 'J': '12.5',
-	\ })<CR>
+	noremap <silent> H <Cmd>call among_HML#fork#init_jump(
+		\ 'H', '0', {
+		\ 'J': '12.5',
+		\ })<CR>
 
-	noremap <silent> K <Cmd>call among_HML#fork#init_jump('K', 25, {
-	\ 'K': '12.5',
-	\ 'J': '37.5',
-	\ })<CR>
+	noremap <silent> K <Cmd>call among_HML#fork#init_jump(
+		\ 'K', 25, {
+		\ 'K': '12.5',
+		\ 'J': '37.5',
+		\ })<CR>
 
-	noremap <silent> M <Cmd>call among_HML#fork#init_jump('M', 50, {
-	\ 'K': '37.5',
-	\ 'J': '67.5',
-	\ })<CR>
+	noremap <silent> M <Cmd>call among_HML#fork#init_jump(
+		\ 'M', 50, {
+		\ 'K': '37.5',
+		\ 'J': '67.5',
+		\ })<CR>
 
-	noremap <silent> J <Cmd>call among_HML#fork#init_jump('J', 75, {
-	\ 'K': '62.5',
-	\ 'J': '87.5',
-	\ })<CR>
+	noremap <silent> J <Cmd>call among_HML#fork#init_jump(
+		\ 'J', 75, {
+		\ 'K': '62.5',
+		\ 'J': '87.5',
+		\ })<CR>
 
-	noremap <silent> L <Cmd>call among_HML#fork#init_jump('L', '100', {
-	\ 'K': '87.5',
-	\ })<CR>
+	noremap <silent> L <Cmd>call among_HML#fork#init_jump(
+		\ 'L', '100', {
+		\ 'K': '87.5',
+		\ })<CR>
 <
 or for less mapped keys, only on H and L for instance,
 >
-	noremap <silent> H <Cmd>call among_HML#fork#init_jump('H', '25', {
-	      \ 'H': '0',
-	      \ 'K': '12.5',
-	      \ 'M': '50',
-	      \ 'J': '37.5',
-	      \ })<CR>
+	noremap <silent> H <Cmd>call among_HML#fork#init_jump(
+		\ 'H', '25', {
+		\ 'H': '0',
+		\ 'K': '12.5',
+		\ 'M': '50',
+		\ 'J': '37.5',
+		\ })<CR>
 
-	noremap <silent> L <Cmd>call among_HML#fork#init_jump('L', '75', {
-	      \ 'K': '62.5',
-	      \ 'J': '87.5',
-	      \ 'M': '50',
-	      \ 'L': '100',
-	      \ })<CR>
+	noremap <silent> L <Cmd>call among_HML#fork#init_jump(
+		\ 'L', '75', {
+		\ 'K': '62.5',
+		\ 'J': '87.5',
+		\ 'M': '50',
+		\ 'L': '100',
+		\ })<CR>
 >
 13 patterns of lines:
 >
-	noremap <silent> H <Cmd>call among_HML#fork#init_jump('H', '0', {
-	      \ 'J': '8.333333',
-	      \ })<CR>
+	noremap <silent> H <Cmd>call among_HML#fork#init_jump(
+		\ 'H', '0', {
+		\ 'J': '8.333333',
+		\ })<CR>
 
-	noremap <silent> K <Cmd>call among_HML#fork#init_jump('K', 25, {
-	      \ 'K': '16.666667',
-	      \ 'J': '33.333333',
-	      \ })<CR>
+	noremap <silent> K <Cmd>call among_HML#fork#init_jump(
+		\ 'K', 25, {
+		\ 'K': '16.666667',
+		\ 'J': '33.333333',
+		\ })<CR>
 
-	noremap <silent> M <Cmd>call among_HML#fork#init_jump('M', 50, {
-	      \ 'K': '41.666667',
-	      \ 'J': '58.333333',
-	      \ })<CR>
+	noremap <silent> M <Cmd>call among_HML#fork#init_jump(
+		\ 'M', 50, {
+		\ 'K': '41.666667',
+		\ 'J': '58.333333',
+		\ })<CR>
 
-	noremap <silent> J <Cmd>call among_HML#fork#init_jump('J', 75, {
-	      \ 'K': '66.666667',
-	      \ 'J': '83.333333',
-	      \ })<CR>
+	noremap <silent> J <Cmd>call among_HML#fork#init_jump(
+		\ 'J', 75, {
+		\ 'K': '66.666667',
+		\ 'J': '83.333333',
+		\ })<CR>
 
-	noremap <silent> L <Cmd>call among_HML#fork#init_jump('L', '100', {
-	      \ 'K': '91.666667',
-	      \ })<CR>
+	noremap <silent> L <Cmd>call among_HML#fork#init_jump( a
+		\ 'L', '100', {
+		\ 'K': '91.666667',
+		\ })<CR>
 <
 Note:
 <Cmd> is only available on neovim v0.3.0 or more, or vim v8.2.1978 or more,

--- a/doc/among_HML.txt
+++ b/doc/among_HML.txt
@@ -130,92 +130,83 @@ For convenience, here are some ratio with percentage in the table below:
 ==============================================================================
 EXAMPLES						 *among_HML-examples*
 
-Note: You must install kana/vim-submode(https://github.com/kana/vim-submode) to
-use among_HML#fork#init().
+Note:
+You must install kana/vim-submode(https://github.com/kana/vim-submode) to use
+|among_HML#fork#init_jump()|.
 
 9 patterns of lines:
 >
-	noremap <silent> H <Cmd>call among_HML#fork#init('H', '0', {
+	noremap <silent> H <Cmd>call among_HML#fork#init_jump('H', '0', {
 	\ 'J': '12.5',
-	\ })<bar>
-	\ call feedkeys('H')<cr>
+	\ })<CR>
 
-	noremap <silent> K <Cmd>call among_HML#fork#init('K', 25, {
+	noremap <silent> K <Cmd>call among_HML#fork#init_jump('K', 25, {
 	\ 'K': '12.5',
 	\ 'J': '37.5',
-	\ })<bar>
-	\ call feedkeys('K')<cr>
+	\ })<CR>
 
-	noremap <silent> M <Cmd>call among_HML#fork#init('M', 50, {
+	noremap <silent> M <Cmd>call among_HML#fork#init_jump('M', 50, {
 	\ 'K': '37.5',
 	\ 'J': '67.5',
-	\ })<bar>
-	\ call feedkeys('M')<cr>
+	\ })<CR>
 
-	noremap <silent> J <Cmd>call among_HML#fork#init('J', 75, {
+	noremap <silent> J <Cmd>call among_HML#fork#init_jump('J', 75, {
 	\ 'K': '62.5',
 	\ 'J': '87.5',
-	\ })<bar>
-	\ call feedkeys('J')<cr>
+	\ })<CR>
 
-	noremap <silent> L <Cmd>call among_HML#fork#init('L', '100', {
+	noremap <silent> L <Cmd>call among_HML#fork#init_jump('L', '100', {
 	\ 'K': '87.5',
-	\ })<bar>
-	\ call feedkeys('L')<cr>
+	\ })<CR>
 <
 or for less mapped keys, only on H and L for instance,
 >
-	noremap <silent> H <Cmd>call among_HML#fork#init('H', '25', {
+	noremap <silent> H <Cmd>call among_HML#fork#init_jump('H', '25', {
 	      \ 'H': '0',
 	      \ 'K': '12.5',
 	      \ 'M': '50',
 	      \ 'J': '37.5',
-	      \ })<bar>
-	      \ call feedkeys('H')<cr>
+	      \ })<CR>
 
-	noremap <silent> L <Cmd>call among_HML#fork#init('L', '75', {
+	noremap <silent> L <Cmd>call among_HML#fork#init_jump('L', '75', {
 	      \ 'K': '62.5',
 	      \ 'J': '87.5',
 	      \ 'M': '50',
 	      \ 'L': '100',
-	      \ })<bar>
-	      \ call feedkeys('L')<cr>
+	      \ })<CR>
 >
 13 patterns of lines:
 >
-	noremap <silent> H <Cmd>call among_HML#fork#init('H', '0', {
+	noremap <silent> H <Cmd>call among_HML#fork#init_jump('H', '0', {
 	      \ 'J': '8.333333',
-	      \ })<bar>
-	      \ call feedkeys('H')<cr>
+	      \ })<CR>
 
-	noremap <silent> K <Cmd>call among_HML#fork#init('K', 25, {
+	noremap <silent> K <Cmd>call among_HML#fork#init_jump('K', 25, {
 	      \ 'K': '16.666667',
 	      \ 'J': '33.333333',
-	      \ })<bar>
-	      \ call feedkeys('K')<cr>
+	      \ })<CR>
 
-	noremap <silent> M <Cmd>call among_HML#fork#init('M', 50, {
+	noremap <silent> M <Cmd>call among_HML#fork#init_jump('M', 50, {
 	      \ 'K': '41.666667',
 	      \ 'J': '58.333333',
-	      \ })<bar>
-	      \ call feedkeys('M')<cr>
+	      \ })<CR>
 
-	noremap <silent> J <Cmd>call among_HML#fork#init('J', 75, {
+	noremap <silent> J <Cmd>call among_HML#fork#init_jump('J', 75, {
 	      \ 'K': '66.666667',
 	      \ 'J': '83.333333',
-	      \ })<bar>
-	      \ call feedkeys('J')<cr>
+	      \ })<CR>
 
-	noremap <silent> L <Cmd>call among_HML#fork#init('L', '100', {
+	noremap <silent> L <Cmd>call among_HML#fork#init_jump('L', '100', {
 	      \ 'K': '91.666667',
-	      \ })<bar>
-	      \ call feedkeys('L')<cr>
+	      \ })<CR>
 <
-Note: <Cmd> is only available on neovim (v0.3.0 or more); in vim, use
+Note:
+<Cmd> is only available on neovim v0.3.0 or more, or vim v8.2.1978 or more,
+use
 >
-	nnoremap (snip) :call among_HML#fork#init(snip)<cr>
+	nnoremap (snip) :call among_HML#fork#init_jump(snip)<cr>
 <
-instead; all the functions shall be useless in `xmap` in vim.
+instead. All the functions shall be useless in `xmap` in this case.
 
 ==============================================================================
 vim:tw=78:ts=8:sts=8:sw=8:ft=help:norl:noet:fen

--- a/doc/among_HML.txt
+++ b/doc/among_HML.txt
@@ -68,44 +68,36 @@ among_HML#get_half#to({expr})		   *among_HML-among_HML#get_half#to()*
 		nnoremap <silent> H  :<c-u>call among_HML#get_half#to(0)<cr>
 		nnoremap <silent> L  :<c-u>call among_HML#get_half#to(100)<cr>
 <
-
-among_HML#fork#init({lhs}, {expr}, {dict})  *among_HML-among_HML#fork#init()*
-		Provides a submode 'HML/fork_{lhs}'. This function depends on
-		kana/vim-submode(https://github.com/kana/vim-submode).
-		{expr} should be a quoted |Float|, which is regarded as a first
-		percentage to jump when entering the submode.
-		You can leave {expr} empty not to jump before forked keymaps.
-		For example,
->
-		let g:submode_keep_leaving_key = 1 " recommended
-
-		:call among_HML#fork#init('M', '50', {
-				\ 'K': '25',
-				\ 'J': '75',
-				\ })
-<
-		For lazy load, you also have |among_HML#fork#init_jump()|.
+among_HML#fork#init()                                 *among_HML#fork#init()*
+		Deprecated. Use |among_HML#fork#init_jump()| instead.
 
 				       *among_HML-among_HML#fork#init_jump()*
 among_HML#fork#init_jump({lhs}, {expr}, {dict})
-		A wrapper function of |among_HML#fork#init()|. Define a submode
-		and then invoke it. This function is supposed to be used in
-		mappings.
+		Depends on
+		kana/vim-submode(https://github.com/kana/vim-submode).
+
+		Defines a submode 'HML/fork_{lhs}' and then invoke it
+		because this function is supposed to be used in mappings.
 >
+		let g:submode_keep_leaving_key = 1 " recommended
+
 		noremap <silent> M <Cmd>call among_HML#fork#init_jump(
 				\ 'M', '50', {
 				\ 'K': '25',
 				\ 'J': '75',
 				\ })<CR>
 <
-		If you prefer not to jump at first, leave the second argument
-		empty.
+		{expr} should be a quoted |Float|, which is regarded as a first
+		percentage to jump when entering the submode. If you prefer
+		not to jump until the second input, set an empty string to the
+		second argument.
 >
 		noremap <silent> M <Cmd>call among_HML#fork#init_jump(
-				\ 'M', '', {
-				\ 'K': '25',
-				\ 'J': '75',
-				\ })<CR>
+			\ 'M', '', {
+			\ 'K': '25',
+			\ 'J': '75',
+			\ })<CR>
+<
 
 For convenience, here are some ratio with percentage in the table below:
 


### PR DESCRIPTION
The old `among_HML#fork#init()` override existing mappings unintentionally.

This PR makes sure that `among_HML#fork#init_jump()` should register the mappings entering submode only within the mode in which the function is mapped. This allows to enable fork-mappings, for example, only in Normal mode and Visual mode, leaving the mappings of Operator-pending mode for another mapping.