### PR TITLE
refactor!: replace percentage with ratio for parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,21 @@ use "aileot/vim-among_HML"
 repo = 'aileot/vim-among_HML'
 ```
 
+## Notice
+
+If you prefer fraction to decimal,
+either numberator or denominator must be a decimal.
+
+In Vim/Neovim, a ratio of Integers is an Integer:
+
+- Either `1/4` or `3/4` results in `0`.
+- `1/4.0` results in `0.25`, `3.0/4` results in `0.75`.
+
 ## Examples
 
 ```vim
-" assign a percentage as you want, like below
-:call among_HML#jump(12.5) " for 1/8 height of lines
+" Assign a ratio (0.0 ~ 1.0) to jump within window.
+:call among_HML#jump(1/8.0) " Jump to 1/8 height in window.
 ```
 
 vim-among_HML defines no default keymappings;
@@ -52,9 +62,9 @@ in your vimrc or init.vim.
 ```vim
 set scrolloff=0 " recommended (default)
 
-" Jump in 1/4 or 3/4 height of lines (i.e., 25% or 75% height);
-noremap <silent> K <Cmd>call among_HML#jump(25)<cr>
-noremap <silent> J <Cmd>call among_HML#jump(75)<cr>
+" Jump into the line at 1/4 or 3/4 height of window (i.e., 25% or 75% height);
+noremap <silent> K <Cmd>call among_HML#jump(0.25)<CR>
+noremap <silent> J <Cmd>call among_HML#jump(0.75)<CR>
 
 " Optional mappings with mnemonics:
 " Get the Keyword
@@ -65,27 +75,6 @@ nnoremap <space>J J
 xnoremap <space>J J
 ```
 
-### Fork Motion
-
-With [kana/vim-submode](https://github.com/kana/vim-submode) installed,
-you can jump in fork.
-
-```vim
-let g:submode_keep_leaving_key = 1 " recommended
-
-noremap <silent> M <Cmd>call among_HML#fork#init_jump(
-      \ 'M', '50', {
-      \ 'H': '0',
-      \ 'K': '25',
-      \ 'J': '75',
-      \ 'L': '100',
-      \ })<CR>
-" Fork mappings are usually annoying in Operator-pending mode.
-ounmap M
-```
-
-Now, you can spare your keymappings.
-
-For more examples and informations, please read documentation
-([online](https://github.com/aileot/vim-among_HML/blob/master/doc/among_HML.txt),
+For more examples and information, please read
+[documentation](https://github.com/aileot/vim-among_HML/blob/master/doc/among_HML.txt),
 or `:h among_HML` in your Vim/Neovim)

--- a/autoload/among_HML.vim
+++ b/autoload/among_HML.vim
@@ -14,14 +14,22 @@ let s:save_cpo = &cpo
 set cpo&vim
 "}}}
 
-function! among_HML#jump(percentage)
+function! among_HML#jump(ratio)
   let save_so = &scrolloff
   set scrolloff=0
+  " Backward compatibility
+  let ratio = a:ratio
+  if a:ratio > 1.0
+    let ratio = a:ratio / 100.0
+    echohl ErrorMsg
+    echom '[among_HML] Percentage is deprecated. Please use a ratio (0.0 ~ 1.0)'
+    echohl None
+  endif
 
   norm! L
-  let dest = round(winline() * a:percentage / 100.0)
+  let dest = round(winline() * ratio)
 
-  if a:percentage <= 50
+  if ratio <= 0.50
     norm! M
   endif
 

--- a/autoload/among_HML.vim
+++ b/autoload/among_HML.vim
@@ -17,9 +17,9 @@ set cpo&vim
 function! among_HML#jump(ratio)
   let save_so = &scrolloff
   set scrolloff=0
-  " Backward compatibility
   let ratio = a:ratio
   if a:ratio > 1.0
+    " Backward compatibility
     let ratio = a:ratio / 100.0
     echohl ErrorMsg
     echom '[among_HML] Percentage is deprecated. Please use a ratio (0.0 ~ 1.0)'

--- a/autoload/among_HML/fork.vim
+++ b/autoload/among_HML/fork.vim
@@ -29,7 +29,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 "}}}
 
-function! s:define_submode(start_key, percentage, combinations)
+function! s:define_submode(start_key, ratio, combinations)
   if has('nvim-0.3.0') || has('patch-8.2.1978')
     let call = '<Cmd>call '
     let modes = 'nxo'
@@ -38,7 +38,7 @@ function! s:define_submode(start_key, percentage, combinations)
     let modes = 'no'
   endif
 
-  let rhs = call .'among_HML#jump('. a:percentage .')<cr>'
+  let rhs = call .'among_HML#jump('. string(a:ratio) .')<cr>'
 
   try
     let mode_name = 'HML/fork_'. a:start_key
@@ -48,7 +48,7 @@ function! s:define_submode(start_key, percentage, combinations)
         call submode#enter_with(mode_name, l:mode, 's', a:start_key, rhs)
         for lhs in keys(a:combinations)
           " Note: option-x makes user leave from the submode
-          let sub_rhs = call .'among_HML#jump('. a:combinations[lhs] .')<CR>'
+          let sub_rhs = call .'among_HML#jump('. string(a:combinations[lhs]) .')<CR>'
           call submode#map(mode_name, l:mode, 'sx', lhs, sub_rhs)
         endfor
       endif

--- a/doc/among_HML.txt
+++ b/doc/among_HML.txt
@@ -28,25 +28,22 @@ USAGE							      *among_HML-usage*
 FUNCTION						  *among_HML-function*
 
 among_HML#jump({expr})				  *among_HML-among_HML#jump()*
-		Move to the line equal to {expr} percentage of lines. {expr}
-		must be a |Float| or a Number. The cursor will keep within the
-		window even when {expr} is a negative or more than 100.
-		For example,
+		Jump to the line in the ratio of current window calculated in
+		{expr}. {expr} must be a |Float| between 0.0 ~ 1.0.
 >
-		:call among_HML#jump(12.5) " for 1/8 height of lines
+		:call among_HML#jump(1.0/8) " Jump to 1/8 of window.
 <
 		vim-among_HML defines no default keymappings, so you should
-		define some keymappings, like below, in your vimrc or init.vim.
+		define some keymappings like below in your vimrc or init.vim.
 >
-		" if you prefer to jump in 1/4 or 3/4 height of lines
-		" (i.e., 25% or 75% height);
-		nnoremap <silent> K :<c-u>call among_HML#jump(25)<cr>
-		nnoremap <silent> J :<c-u>call among_HML#jump(75)<cr>
+		" If you prefer to jump in 1/4 or 3/4 of window.
+		nnoremap <silent> K :<C-u>call among_HML#jump(0.25)<CR>
+		nnoremap <silent> J :<C-u>call among_HML#jump(0.75)<CR>
 
-		onoremap <silent> K :call among_HML#jump(25)<cr>
-		onoremap <silent> J :call among_HML#jump(75)<cr>
+		onoremap <silent> K :call among_HML#jump(0.25)<CR>
+		onoremap <silent> J :call among_HML#jump(0.75)<CR>
 
-		" optional:
+		" (Optional)
 		" Mnemonic: Get the Keyword
 		nnoremap gK K
 		" Mnemonic: <space>-leaving Join
@@ -55,18 +52,18 @@ among_HML#jump({expr})				  *among_HML-among_HML#jump()*
 		When either `has('nvim-0.3.0')` or `has('patch-8.2.1978')` returns
 		`1`, you can define keymappings with `<Cmd>` as below:
 >
-		noremap <silent> K <Cmd>call among_HML#jump(25)<cr>
-		noremap <silent> J <Cmd>call among_HML#jump(75)<cr>
+		noremap <silent> K <Cmd>call among_HML#jump(0.25)<CR>
+		noremap <silent> J <Cmd>call among_HML#jump(0.75)<CR>
 		noremap gK K
 		noremap <space>J J
 >
 among_HML#get_half#to({expr})		   *among_HML-among_HML#get_half#to()*
 		Jump to the middle line between current cursor line and
 		specified end of line. The rule of argument should follow
-		|among_HML#percent()|. For example,
+		|among_HML#jump()|. For example,
 >
-		nnoremap <silent> H  :<c-u>call among_HML#get_half#to(0)<cr>
-		nnoremap <silent> L  :<c-u>call among_HML#get_half#to(100)<cr>
+		nnoremap <silent> H  :<C-u>call among_HML#get_half#to(0.0)<CR>
+		nnoremap <silent> L  :<C-u>call among_HML#get_half#to(1.0)<CR>
 <
 among_HML#fork#init()                                 *among_HML#fork#init()*
 		Deprecated. Use |among_HML#fork#init_jump()| instead.
@@ -82,43 +79,22 @@ among_HML#fork#init_jump({lhs}, {expr}, {dict})
 		let g:submode_keep_leaving_key = 1 " recommended
 
 		noremap <silent> M <Cmd>call among_HML#fork#init_jump(
-				\ 'M', '50', {
-				\ 'K': '25',
-				\ 'J': '75',
+				\ 'M', 0.50, {
+				\ 'K': 0.25,
+				\ 'J': 0.75,
 				\ })<CR>
 <
-		{expr} should be a quoted |Float|, which is regarded as a first
-		percentage to jump when entering the submode. If you prefer
-		not to jump until the second input, set an empty string to the
-		second argument.
+		{expr} should be a |Float|, which is regarded as the first ratio
+		to jump when entering the submode. If you prefer not to jump
+		until the second input, set an empty string to the second
+		argument.
 >
 		noremap <silent> M <Cmd>call among_HML#fork#init_jump(
 			\ 'M', '', {
-			\ 'K': '25',
-			\ 'J': '75',
+			\ 'K': 0.25,
+			\ 'J': 0.75,
 			\ })<CR>
 <
-
-For convenience, here are some ratio with percentage in the table below:
-
-	| ratio | percentage |
-	| ===== | ========== |
-	| 0     | 0          |
-	| 1/8   | 12.5       |
-	| 1/6   | 16.666667  |
-	| 1/4   | 25         |
-	| 1/3   | 33.333333  |
-	| 3/8   | 37.5       |
-	| ----- | ---------- |
-	| 1/2   | 50         |
-	| ----- | ---------- |
-	| 5/8   | 62.5       |
-	| 2/3   | 66.666667  |
-	| 3/4   | 75         |
-	| 5/6   | 83.333333  |
-	| 7/8   | 87.5       |
-	| 1     | 100        |
-
 ==============================================================================
 EXAMPLES						   *among_HML-examples*
 
@@ -129,86 +105,56 @@ You must install kana/vim-submode(https://github.com/kana/vim-submode) to use
 9 patterns of lines:
 >
 	noremap <silent> H <Cmd>call among_HML#fork#init_jump(
-		\ 'H', '0', {
-		\ 'J': '12.5',
+		\ 'H', 0.0, {
+		\ 'J': 0.125,
 		\ })<CR>
 
 	noremap <silent> K <Cmd>call among_HML#fork#init_jump(
-		\ 'K', 25, {
-		\ 'K': '12.5',
-		\ 'J': '37.5',
+		\ 'K', 0.25, {
+		\ 'K': 0.125,
+		\ 'J': 0.375,
 		\ })<CR>
 
 	noremap <silent> M <Cmd>call among_HML#fork#init_jump(
-		\ 'M', 50, {
-		\ 'K': '37.5',
-		\ 'J': '67.5',
+		\ 'M', 0.50, {
+		\ 'K': 0.375,
+		\ 'J': 0.675,
 		\ })<CR>
 
 	noremap <silent> J <Cmd>call among_HML#fork#init_jump(
-		\ 'J', 75, {
-		\ 'K': '62.5',
-		\ 'J': '87.5',
+		\ 'J', 0.75, {
+		\ 'K': 0.625,
+		\ 'J': 0.875,
 		\ })<CR>
 
 	noremap <silent> L <Cmd>call among_HML#fork#init_jump(
-		\ 'L', '100', {
-		\ 'K': '87.5',
+		\ 'L', 1.0, {
+		\ 'K': 0.875,
 		\ })<CR>
 <
 or for less mapped keys, only on H and L for instance,
 >
 	noremap <silent> H <Cmd>call among_HML#fork#init_jump(
-		\ 'H', '25', {
-		\ 'H': '0',
-		\ 'K': '12.5',
-		\ 'M': '50',
-		\ 'J': '37.5',
+		\ 'H', 0.25, {
+		\ 'H': 0.0,
+		\ 'K': 0.125,
+		\ 'M': 0.50,
+		\ 'J': 0.375,
 		\ })<CR>
 
 	noremap <silent> L <Cmd>call among_HML#fork#init_jump(
-		\ 'L', '75', {
-		\ 'K': '62.5',
-		\ 'J': '87.5',
-		\ 'M': '50',
-		\ 'L': '100',
-		\ })<CR>
->
-13 patterns of lines:
->
-	noremap <silent> H <Cmd>call among_HML#fork#init_jump(
-		\ 'H', '0', {
-		\ 'J': '8.333333',
+		\ 'L', 0.75, {
+		\ 'K': 0.625,
+		\ 'J': 0.875,
+		\ 'M': 0.50,
+		\ 'L': 1.0,
 		\ })<CR>
 
-	noremap <silent> K <Cmd>call among_HML#fork#init_jump(
-		\ 'K', 25, {
-		\ 'K': '16.666667',
-		\ 'J': '33.333333',
-		\ })<CR>
-
-	noremap <silent> M <Cmd>call among_HML#fork#init_jump(
-		\ 'M', 50, {
-		\ 'K': '41.666667',
-		\ 'J': '58.333333',
-		\ })<CR>
-
-	noremap <silent> J <Cmd>call among_HML#fork#init_jump(
-		\ 'J', 75, {
-		\ 'K': '66.666667',
-		\ 'J': '83.333333',
-		\ })<CR>
-
-	noremap <silent> L <Cmd>call among_HML#fork#init_jump( a
-		\ 'L', '100', {
-		\ 'K': '91.666667',
-		\ })<CR>
-<
 Note:
 <Cmd> is only available on neovim v0.3.0 or more, or vim v8.2.1978 or more,
 use
 >
-	nnoremap (snip) :call among_HML#fork#init_jump(snip)<cr>
+	nnoremap (snip) :call among_HML#fork#init_jump(snip)<CR>
 <
 instead. All the functions shall be useless in `xmap` in this case.
 


### PR DESCRIPTION
That lets us drop excessive `* 100` from our vimrcs.